### PR TITLE
Update ActiveModel errors for Rails 6.1 compatability

### DIFF
--- a/dynamic_form.gemspec
+++ b/dynamic_form.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{dynamic_form}
-  s.version = "1.1.5"
+  s.version = "2.0.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Flux Federation Ltd"]

--- a/lib/active_model/dynamic_errors.rb
+++ b/lib/active_model/dynamic_errors.rb
@@ -2,38 +2,33 @@ module ActiveModel
   class Errors
     # Redefine the ActiveModel::Errors::full_messages method:
     #  Returns all the full error messages in an array. 'Base' messages are handled as usual.
-    #  Non-base messages are prefixed with the attribute name as usual UNLESS 
+    #  Non-base messages are prefixed with the attribute name as usual UNLESS
     # (1) they begin with '^' in which case the attribute name is omitted.
     #     E.g. validates_acceptance_of :accepted_terms, :message => '^Please accept the terms of service'
     # (2) the message is a proc, in which case the proc is invoked on the model object.
-    #     E.g. validates_presence_of :assessment_answer_option_id, 
+    #     E.g. validates_presence_of :assessment_answer_option_id,
     #     :message => Proc.new { |aa| "#{aa.label} (#{aa.group_label}) is required" }
     #     which gives an error message like:
     #     Rate (Accuracy) is required
     def full_messages
       full_messages = []
 
-      each do |attribute, messages|
-        messages = Array.wrap(messages)
-        next if messages.empty?
-
-        if attribute == :base
-          messages.each {|m| full_messages << m }
+      each do |error|
+        if error.attribute == :base
+          full_messages << error.message
         else
-          attr_name = attribute.to_s.gsub('.', '_').humanize
-          attr_name = @base.class.human_attribute_name(attribute, :default => attr_name)
+          attr_name = error.attribute.to_s.gsub('.', '_').humanize
+          attr_name = @base.class.human_attribute_name(error.attribute, :default => attr_name)
           options = { :default => "%{attribute} %{message}", :attribute => attr_name }
 
-          messages.each do |m|
-            if m =~ /^\^/
-              options[:default] = "%{message}"
-              full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => m[1..-1]))
-            elsif m.is_a? Proc
-              options[:default] = "%{message}"
-              full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => m.call(@base)))
-            else
-              full_messages << I18n.t(:"errors.format", **options.merge(:message => m))
-            end            
+          if error.message =~ /^\^/
+            options[:default] = "%{message}"
+            full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error.message[1..-1]))
+          elsif error.message.is_a? Proc
+            options[:default] = "%{message}"
+            full_messages << I18n.t(:"errors.dynamic_format", **options.merge(:message => error.message.call(@base)))
+          else
+            full_messages << I18n.t(:"errors.format", **options.merge(:message => error.message))
           end
         end
       end


### PR DESCRIPTION
Make v2 that will be compatible with Rails 6.1
It is NOT backwards compatible with < 6.1 - hence the bump to a new major version